### PR TITLE
Add more bootstrap containers to base template to better control the layout

### DIFF
--- a/templates/wafer/base.html
+++ b/templates/wafer/base.html
@@ -23,9 +23,9 @@
     <h1>{{ WAFER_CONFERENCE_NAME }}</h1>
 {% endblock %}
         </div>
-        <div id="logos">
+        <div id="logos" class="container">
         </div>
-        <div id="legal">&copy; 2017 PyCon ZA.</div>
+        <div id="legal" class="container">&copy; 2017 PyCon ZA.</div>
         <div id="logo_bottom"><img src="{{ STATIC_URL }}img/logo_bottom.png" /></div>
     </div>
     <div id="footer" class="{{ WAFER_NAVIGATION_VISIBILITY }}">


### PR DESCRIPTION
Current, the copyright year tends to float to the right of the main section on wide displays. This wraps the logo and copyright sections in their own containers to better control how the layout works.