### PR TITLE
Change colour of links in schedule headers

### DIFF
--- a/static/css/pyconza2017.css
+++ b/static/css/pyconza2017.css
@@ -117,6 +117,11 @@ table td {
   vertical-align: top;
 }
 
+/* Make links on the table header visbile */
+#main table th a {
+  color: #191919;
+}
+
 #main table th span {
   font-size: 16px;
   font-weight: bold;


### PR DESCRIPTION
The default colour for links exactly matches the header colour in the schedule, making the room names invisible.

This sets them to the same colour as the 'Time' header. It may be better to use a different colour to make it more obvious that these are links, but this is an improvement on the current situation.