### PR TITLE
Add custom style for open spaces, so they're visually distinct from ordinary talks

### DIFF
--- a/static/css/pyconza2017.css
+++ b/static/css/pyconza2017.css
@@ -177,6 +177,11 @@ table td {
   background: #ebbdec;
 }
 
+/* Different colour for open spaces, so they don't look like talks */
+#main table td.talk-type-open-space {
+  background: #ecd3bd;
+}
+
 /* Use a darker background for unavailable venues in the schedule */
 #main table td.unavailable {
   background: #444444;


### PR DESCRIPTION
If we're going to have open spaces on the schedule, they should not look like talks.